### PR TITLE
Eigen include fix

### DIFF
--- a/Tudat/External/JsonInterface/Support/utilities.h
+++ b/Tudat/External/JsonInterface/Support/utilities.h
@@ -21,7 +21,7 @@
 
 #include <boost/filesystem.hpp>
 
-#include <eigen/Eigen>
+#include <Eigen/Core>
 
 namespace tudat
 {


### PR DESCRIPTION
Not sure why this works on OS X. But on Linux this reports that the header can't be found

```
In file included from /home/jacco/tudat-matlab/tudatBundle/tudat/Tudat/External/JsonInterface/Support/deserialization.cpp:16:0:
/home/jacco/tudat-matlab/tudatBundle/tudat/Tudat/External/JsonInterface/Support/utilities.h:24:10: fatal error: eigen/Eigen: No such file or directory
 #include <eigen/Eigen>

          ^~~~~~~~~~~~~
compilation terminated.
```